### PR TITLE
Voice Activity Detection 

### DIFF
--- a/VoiceActivityDetection.py
+++ b/VoiceActivityDetection.py
@@ -7,7 +7,7 @@ __doc__ = \
     These functions can be used in most base functions by passing VAD = myVADfunction where
     myVADfunction follows the template provided.
     """
-
+import numpy as np
 
 def templateVAD(frames, sig):
     """
@@ -28,7 +28,7 @@ def simpleVAD(frames, sig, threshold=0.01):
     Note that the variance of frame/signal represents the average power of the frame/signal
     so this is a power threshold activity detector applied along the frames
     """
-    import numpy as np
+
 
     frameVars = np.var(frames, 1)
     reducedFrames = frames[np.where(frameVars > sig.var() * threshold)]

--- a/example.py
+++ b/example.py
@@ -6,4 +6,13 @@ import scipy.io.wavfile as wav
 mfcc_feat = mfcc(sig,rate)
 fbank_feat = logfbank(sig,rate)
 
-print fbank_feat[1:3,:]
+# print fbank_feat[1:3,:]
+print mfcc_feat[1:3,:]
+
+#Voice Activity detection example
+from VoiceActivityDetection import simpleVAD
+
+print mfcc_feat.shape
+mfcc_feat = mfcc(sig,rate, VAD=simpleVAD)
+print mfcc_feat.shape
+

--- a/features/base.py
+++ b/features/base.py
@@ -3,42 +3,41 @@
 import numpy
 from features import sigproc
 from scipy.fftpack import dct
-
-
-def mfcc(signal, samplerate=16000, winlen=0.025, winstep=0.01, numcep=13, nfilt=26, nfft=512, lowfreq=0, highfreq=None,
-         preemph=0.97, ceplifter=22, appendEnergy=True, VAD=None):
+    
+def mfcc(signal,samplerate=16000,winlen=0.025,winstep=0.01,numcep=13,
+          nfilt=26,nfft=512,lowfreq=0,highfreq=None,preemph=0.97,ceplifter=22,appendEnergy=True, VAD=None):
     """Compute MFCC features from an audio signal.
 
     :param signal: the audio signal from which to compute features. Should be an N*1 array
     :param samplerate: the samplerate of the signal we are working with.
-    :param winlen: the length of the analysis window in seconds. Default is 0.025s (25 milliseconds)
-    :param winstep: the step between successive windows in seconds. Default is 0.01s (10 milliseconds)
-    :param numcep: the number of cepstrum to return, default 13
+    :param winlen: the length of the analysis window in seconds. Default is 0.025s (25 milliseconds)    
+    :param winstep: the step between successive windows in seconds. Default is 0.01s (10 milliseconds)    
+    :param numcep: the number of cepstrum to return, default 13    
     :param nfilt: the number of filters in the filterbank, default 26.
     :param nfft: the FFT size. Default is 512.
     :param lowfreq: lowest band edge of mel filters. In Hz, default is 0.
     :param highfreq: highest band edge of mel filters. In Hz, default is samplerate/2
-    :param preemph: apply preemphasis filter with preemph as coefficient. 0 is no filter. Default is 0.97.
-    :param ceplifter: apply a lifter to final cepstral coefficients. 0 is no lifter. Default is 22.
+    :param preemph: apply preemphasis filter with preemph as coefficient. 0 is no filter. Default is 0.97. 
+    :param ceplifter: apply a lifter to final cepstral coefficients. 0 is no lifter. Default is 22. 
     :param appendEnergy: if this is true, the zeroth cepstral coefficient is replaced with the log of the total frame energy.
-    :param VAD: Voice Activity Detection function, see VoiceActivityDetection.py, default is None
+    :param VAD: Voice Activity Detection function, see VoiceActivityDetection.py
     :returns: A numpy array of size (NUMFRAMES by numcep) containing features. Each row holds 1 feature vector.
-    """
-    feat, energy = fbank(signal, samplerate, winlen, winstep, nfilt, nfft, lowfreq, highfreq, preemph, VAD)
+    """            
+    feat,energy = fbank(signal,samplerate,winlen,winstep,nfilt,nfft,lowfreq,highfreq,preemph, VAD)
     feat = numpy.log(feat)
     feat = dct(feat, type=2, axis=1, norm='ortho')[:,:numcep]
     feat = lifter(feat,ceplifter)
     if appendEnergy: feat[:,0] = numpy.log(energy) # replace first cepstral coefficient with log of frame energy
     return feat
 
-def fbank(signal, samplerate=16000, winlen=0.025, winstep=0.01, nfilt=26, nfft=512, lowfreq=0, highfreq=None,
-          preemph=0.97, VAD=None):
+def fbank(signal,samplerate=16000,winlen=0.025,winstep=0.01,
+          nfilt=26,nfft=512,lowfreq=0,highfreq=None,preemph=0.97, VAD = None):
     """Compute Mel-filterbank energy features from an audio signal.
 
     :param signal: the audio signal from which to compute features. Should be an N*1 array
     :param samplerate: the samplerate of the signal we are working with.
-    :param winlen: the length of the analysis window in seconds. Default is 0.025s (25 milliseconds)
-    :param winstep: the step between seccessive windows in seconds. Default is 0.01s (10 milliseconds)
+    :param winlen: the length of the analysis window in seconds. Default is 0.025s (25 milliseconds)    
+    :param winstep: the step between seccessive windows in seconds. Default is 0.01s (10 milliseconds)    
     :param nfilt: the number of filters in the filterbank, default 26.
     :param nfft: the FFT size. Default is 512.
     :param lowfreq: lowest band edge of mel filters. In Hz, default is 0.
@@ -47,10 +46,10 @@ def fbank(signal, samplerate=16000, winlen=0.025, winstep=0.01, nfilt=26, nfft=5
     :param VAD: Voice Activity Detection function, see VoiceActivityDetection.py
     :returns: 2 values. The first is a numpy array of size (NUMFRAMES by nfilt) containing features. Each row holds 1 feature vector. The
         second return value is the energy in each frame (total energy, unwindowed)
-    """
-    highfreq = highfreq or samplerate / 2
+    """          
+    highfreq= highfreq or samplerate/2
     signal = sigproc.preemphasis(signal,preemph)
-    frames = sigproc.framesig(signal, winlen * samplerate, winstep * samplerate, VAD=VAD)
+    frames = sigproc.framesig(signal, winlen*samplerate, winstep*samplerate, VAD=VAD)
     pspec = sigproc.powspec(frames,nfft)
     energy = numpy.sum(pspec,1) # this stores the total energy in each frame
     
@@ -58,44 +57,44 @@ def fbank(signal, samplerate=16000, winlen=0.025, winstep=0.01, nfilt=26, nfft=5
     feat = numpy.dot(pspec,fb.T) # compute the filterbank energies
     return feat,energy
 
-def logfbank(signal, samplerate=16000, winlen=0.025, winstep=0.01, nfilt=26, nfft=512, lowfreq=0, highfreq=None,
-             preemph=0.97, VAD=None):
+def logfbank(signal,samplerate=16000,winlen=0.025,winstep=0.01,
+          nfilt=26,nfft=512,lowfreq=0,highfreq=None,preemph=0.97, VAD = None):
     """Compute log Mel-filterbank energy features from an audio signal.
 
     :param signal: the audio signal from which to compute features. Should be an N*1 array
     :param samplerate: the samplerate of the signal we are working with.
-    :param winlen: the length of the analysis window in seconds. Default is 0.025s (25 milliseconds)
-    :param winstep: the step between seccessive windows in seconds. Default is 0.01s (10 milliseconds)
+    :param winlen: the length of the analysis window in seconds. Default is 0.025s (25 milliseconds)    
+    :param winstep: the step between seccessive windows in seconds. Default is 0.01s (10 milliseconds)    
     :param nfilt: the number of filters in the filterbank, default 26.
     :param nfft: the FFT size. Default is 512.
     :param lowfreq: lowest band edge of mel filters. In Hz, default is 0.
     :param highfreq: highest band edge of mel filters. In Hz, default is samplerate/2
     :param preemph: apply preemphasis filter with preemph as coefficient. 0 is no filter. Default is 0.97.
     :param VAD: Voice Activity Detection function, see VoiceActivityDetection.py
-    :returns: A numpy array of size (NUMFRAMES by nfilt) containing features. Each row holds 1 feature vector.
-    """
-    feat, energy = fbank(signal, samplerate, winlen, winstep, nfilt, nfft, lowfreq, highfreq, preemph)
+    :returns: A numpy array of size (NUMFRAMES by nfilt) containing features. Each row holds 1 feature vector. 
+    """          
+    feat,energy = fbank(signal,samplerate,winlen,winstep,nfilt,nfft,lowfreq,highfreq,preemph, VAD)
     return numpy.log(feat)
 
-def ssc(signal, samplerate=16000, winlen=0.025, winstep=0.01, nfilt=26, nfft=512, lowfreq=0, highfreq=None,
-        preemph=0.97, VAD=None):
+def ssc(signal,samplerate=16000,winlen=0.025,winstep=0.01,
+          nfilt=26,nfft=512,lowfreq=0,highfreq=None,preemph=0.97, VAD = None):
     """Compute Spectral Subband Centroid features from an audio signal.
 
     :param signal: the audio signal from which to compute features. Should be an N*1 array
     :param samplerate: the samplerate of the signal we are working with.
-    :param winlen: the length of the analysis window in seconds. Default is 0.025s (25 milliseconds)
-    :param winstep: the step between seccessive windows in seconds. Default is 0.01s (10 milliseconds)
+    :param winlen: the length of the analysis window in seconds. Default is 0.025s (25 milliseconds)    
+    :param winstep: the step between seccessive windows in seconds. Default is 0.01s (10 milliseconds)    
     :param nfilt: the number of filters in the filterbank, default 26.
     :param nfft: the FFT size. Default is 512.
     :param lowfreq: lowest band edge of mel filters. In Hz, default is 0.
     :param highfreq: highest band edge of mel filters. In Hz, default is samplerate/2
     :param preemph: apply preemphasis filter with preemph as coefficient. 0 is no filter. Default is 0.97.
     :param VAD: Voice Activity Detection function, see VoiceActivityDetection.py
-    :returns: A numpy array of size (NUMFRAMES by nfilt) containing features. Each row holds 1 feature vector.
+    :returns: A numpy array of size (NUMFRAMES by nfilt) containing features. Each row holds 1 feature vector. 
     """          
     highfreq= highfreq or samplerate/2
     signal = sigproc.preemphasis(signal,preemph)
-    frames = sigproc.framesig(signal, winlen * samplerate, winstep * samplerate, VAD=VAD)
+    frames = sigproc.framesig(signal, winlen*samplerate, winstep*samplerate, VAD=VAD)
     pspec = sigproc.powspec(frames,nfft)
     
     fb = get_filterbanks(nfilt,nfft,samplerate)

--- a/features/sigproc.py
+++ b/features/sigproc.py
@@ -1,11 +1,10 @@
 # This file includes routines for basic signal processing including framing and computing power spectra.
 # Author: James Lyons 2012
 
-import math
 import numpy
+import math
 
-
-def framesig(sig, frame_len, frame_step, winfunc=lambda x: numpy.ones((1, x)), VAD=None):
+def framesig(sig,frame_len,frame_step,winfunc=lambda x:numpy.ones((1,x)), VAD=None):
     """Frame a signal into overlapping frames.
 
     :param sig: the audio signal to frame.
@@ -36,11 +35,13 @@ def framesig(sig, frame_len, frame_step, winfunc=lambda x: numpy.ones((1, x)), V
         frames = VAD(frames, sig)
 
     win = numpy.tile(winfunc(frame_len), (frames.shape[0], 1))
+
     return frames*win
     
     
 def deframesig(frames,siglen,frame_len,frame_step,winfunc=lambda x:numpy.ones((1,x))):
-    """Does overlap-add procedure to undo the action of framesig. 
+    """Does overlap-add procedure to undo the action of framesig.
+    Not applicable if Voice Activity Detection has been used in framesig
 
     :param frames: the array of frames.
     :param siglen: the length of the desired signal, use 0 if unknown. Output will be truncated to siglen samples.    
@@ -97,8 +98,8 @@ def logpowspec(frames,NFFT,norm=1):
     :param NFFT: the FFT length to use. If NFFT > frame_len, the frames are zero-padded. 
     :param norm: If norm=1, the log power spectrum is normalised so that the max value (across all frames) is 1.
     :returns: If frames is an NxD matrix, output will be NxNFFT. Each row will be the log power spectrum of the corresponding frame.
-    """
-    ps = powspec(frames, NFFT)
+    """    
+    ps = powspec(frames,NFFT);
     ps[ps<=1e-30] = 1e-30
     lps = 10*numpy.log10(ps)
     if norm:


### PR DESCRIPTION
![typicalvoicesample](https://cloud.githubusercontent.com/assets/1589119/4913081/22560f1a-64aa-11e4-9d83-4922caa4074c.png)

In a typical voice sample, you can see that a significant portion of the speech does not consist of any activity, so in typical speech applications, the regions that don't have much happening are instead removed, as this results in us extracting the MFCCs of silence which aren't very helpful in most situations.

I've modified your code slightly to allow for Voice Activity Detection, it's default behaviour is still intact, but if someone wishes to implement a Voice Activity detector function they have the template, documentation and a simple threshold to play with, as well as an example showing simple applications. 

The code allows for passing of the frames and the entire signal, which should be flexible enough for anyone to write their own versions depending on their purpose. I considered using the frame power provided as the first MFCC, but decided that this was overall more flexible, and allowed comparison to the entire signal at once.

This is a modification I made for my thesis in which I used your code to extract the MFCCs from a bunch of files, and I thought other people may find this handy too.
