### PR TITLE
docs: fix simple typo, seccessive -> successive

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -89,7 +89,7 @@ Parameter 		Description
 signal			the audio signal from which to compute features. Should be an N*1 array
 samplerate		the samplerate of the signal we are working with
 winlen			the length of the analysis window in seconds. Default is 0.025s (25 milliseconds)
-winstep			the step between seccessive windows in seconds. Default is 0.01s (10 milliseconds)
+winstep			the step between successive windows in seconds. Default is 0.01s (10 milliseconds)
 nfilt			the number of filters in the filterbank, default 26.
 nfft			the FFT size. Default is 512.
 lowfreq			lowest band edge of mel filters. In Hz, default is 0


### PR DESCRIPTION
There is a small typo in README.rst.

Should read `successive` rather than `seccessive`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md